### PR TITLE
feat: fetch farms from server

### DIFF
--- a/src/app/farm/farm-list/farm-list.component.html
+++ b/src/app/farm/farm-list/farm-list.component.html
@@ -1,1 +1,13 @@
 <button (click)="openAddFarmModal()">Nova Fazenda</button>
+
+<div *ngIf="farms.length == 0">
+    <p>Sem fazendas</p>
+</div>
+
+<div *ngIf="farms.length != 0">
+    <table>
+        <tr *ngFor="let farm of farms">
+            <td> {{ farm.name }} </td>
+        </tr>
+    </table>
+</div>

--- a/src/app/farm/farm-list/farm-list.component.ts
+++ b/src/app/farm/farm-list/farm-list.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
+import { Farm } from 'src/app/interfaces/farm.model';
+import { FarmService } from 'src/app/service/farm.service';
 import { AddFarmModalComponent } from '../add-farm-modal/add-farm-modal.component';
 
 @Component({
@@ -9,24 +11,40 @@ import { AddFarmModalComponent } from '../add-farm-modal/add-farm-modal.componen
 })
 export class FarmListComponent implements OnInit {
 
+  farms: Farm[] = [];
+
   constructor(
-    public dialog: MatDialog
+    public dialog: MatDialog,
+    private farmService: FarmService
   ) { }
 
   ngOnInit(): void {
+    this.getFarms();
+  }
+
+  public getFarms() {
+    this.farmService.getAllFarms().subscribe({
+      next: (responseData) => {
+        console.log(responseData);
+        this.farms = responseData;
+      },
+      error: (e) => console.error(e)
+    })
   }
 
   openAddFarmModal() {
     this.dialog
       .open(AddFarmModalComponent, {
         width: '600px',
-      });
-      // .afterClosed()
-      // .subscribe(async (response) => {
-      //   if(response.button === 'salvar'){
-      //     alert('Farm Saved!');
-      //   }
-      // })
+      })
+      .afterClosed()
+      .subscribe(async (response) => {
+        if(response.button === 'salvar'){
+          this.getFarms();
+        }
+      })
   }
+
+
 
 }

--- a/src/app/interfaces/farm.model.ts
+++ b/src/app/interfaces/farm.model.ts
@@ -1,4 +1,5 @@
 export interface Farm {
     id?: string;
     name: string;
+    productivity?: string;
 }

--- a/src/app/service/farm.service.ts
+++ b/src/app/service/farm.service.ts
@@ -10,6 +10,14 @@ export class FarmService {
 
   constructor(private api: HttpService) { }
 
+  public getAllFarms() {
+    return this.api.get<Farm[]>(API_URL + '/farm/');
+  }
+
+  public getFarmById(id: string) {
+    return this.api.get<Farm[]>(API_URL + '/farm/' + id);
+  }
+
   public addFarm(farm: Farm) {
     return this.api.post<Farm>(API_URL + '/farm', farm);
   }

--- a/src/app/service/http.service.ts
+++ b/src/app/service/http.service.ts
@@ -14,6 +14,12 @@ export class HttpService {
 
   constructor(private http: HttpClient) { }
 
+  public get<T>(url: string): Observable<T> {
+    return this.http
+      .get<T>(url)
+      .pipe(catchError(errorHandler));
+  }
+
   public post<T>(url: string, data: any): Observable<T> {
     return this.http
       .post<T>(url, data, headers)


### PR DESCRIPTION
A ideia desse commit foi implementar a lógica pra recuperar as fazendas cadastradas por meio de uma get request. Todas as fazendas cadastradas são exibidas no componente farm-list, que é o principal componente pelo routing. A cada interação com a janela de diálogo que faz o cadastro das fazendas que resulte em uma nova fazenda adicionada, a lista é redesenhada. Alguma sugestão do que posso melhorar?

![image](https://user-images.githubusercontent.com/103016217/170887854-e57f5805-d349-40b9-b654-f6236f5047ad.png)
![image](https://user-images.githubusercontent.com/103016217/170887881-f456578b-01e1-419c-9802-2a1404dac6b3.png)
![image](https://user-images.githubusercontent.com/103016217/170887913-b96a8e78-b6b0-48c8-b212-5bb5700e6f6c.png)
![image](https://user-images.githubusercontent.com/103016217/170887919-cd58d156-dec3-4497-9936-b2c572d0812a.png)
