### PR TITLE
feat: delete farm on server

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppComponent } from './app.component';
 import { FarmListComponent } from './farm/farm-list/farm-list.component';
 import { AddFarmModalComponent } from './farm/add-farm-modal/add-farm-modal.component';
+import { DeleteFarmModalComponent } from './farm/delete-farm-modal/delete-farm-modal.component';
 
 
 
@@ -16,7 +17,8 @@ import { AddFarmModalComponent } from './farm/add-farm-modal/add-farm-modal.comp
   declarations: [
     AppComponent,
     FarmListComponent,
-    AddFarmModalComponent
+    AddFarmModalComponent,
+    DeleteFarmModalComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/farm/delete-farm-modal/delete-farm-modal.component.html
+++ b/src/app/farm/delete-farm-modal/delete-farm-modal.component.html
@@ -1,0 +1,7 @@
+<h1>Deletar {{farm.name}}</h1>
+<p>Deletar a {{farm.name}} fará com que todos os seus itens sejam removidos. Deseja continuar?</p>
+
+<div mat-dialog-actions>
+    <button mat-button (click)="closeDialog()">Cancelar</button>
+    <button mat-button (click)="deleteFarm()">Deletar</button>
+</div>

--- a/src/app/farm/delete-farm-modal/delete-farm-modal.component.spec.ts
+++ b/src/app/farm/delete-farm-modal/delete-farm-modal.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteFarmModalComponent } from './delete-farm-modal.component';
+
+describe('DeleteFarmModalComponent', () => {
+  let component: DeleteFarmModalComponent;
+  let fixture: ComponentFixture<DeleteFarmModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DeleteFarmModalComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DeleteFarmModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/farm/delete-farm-modal/delete-farm-modal.component.ts
+++ b/src/app/farm/delete-farm-modal/delete-farm-modal.component.ts
@@ -1,0 +1,41 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Farm } from 'src/app/interfaces/farm.model';
+import { FarmService } from 'src/app/service/farm.service';
+
+@Component({
+  selector: 'app-delete-farm-modal',
+  templateUrl: './delete-farm-modal.component.html',
+  styleUrls: ['./delete-farm-modal.component.css']
+})
+export class DeleteFarmModalComponent implements OnInit {
+
+  farm: Farm = this.data.farm;
+  
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: {farm: Farm},
+    private farmService: FarmService,
+    private dialogRef: MatDialogRef<DeleteFarmModalComponent>
+  ) { }
+
+  ngOnInit(): void {}
+  
+  public deleteFarm(): void {
+    this.farmService.deleteFarm(this.farm.id!).subscribe({
+      next: (responseData) => {
+        console.log(responseData),
+        this.dialogRef.close({ button: 'deletar'});
+      },
+        error: (e) => {
+        console.error(e),
+        alert('Erro ao deletar Fazenda');
+        this.closeDialog();
+      }
+    });
+  }
+
+  closeDialog() {
+    this.dialogRef.close({ button: 'cancelar'});
+  }
+
+}

--- a/src/app/farm/farm-list/farm-list.component.html
+++ b/src/app/farm/farm-list/farm-list.component.html
@@ -9,7 +9,7 @@
         <tr *ngFor="let farm of farms">
             <td> {{ farm.name }} </td>
             <td><button (click)="openAddFarmModal(farm)">edit</button></td>
-            <td><button>delete</button></td>
+            <td><button (click)="openDeleteFarmModal(farm)">delete</button></td>
         </tr>
     </table>
 </div>

--- a/src/app/farm/farm-list/farm-list.component.ts
+++ b/src/app/farm/farm-list/farm-list.component.ts
@@ -3,6 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Farm } from 'src/app/interfaces/farm.model';
 import { FarmService } from 'src/app/service/farm.service';
 import { AddFarmModalComponent } from '../add-farm-modal/add-farm-modal.component';
+import { DeleteFarmModalComponent } from '../delete-farm-modal/delete-farm-modal.component';
 
 @Component({
   selector: 'app-farm-list',
@@ -22,7 +23,7 @@ export class FarmListComponent implements OnInit {
     this.getFarms();
   }
 
-  public getFarms() {
+  public getFarms(): void {
     this.farmService.getAllFarms().subscribe({
       next: (responseData) => {
         console.log(responseData);
@@ -32,7 +33,7 @@ export class FarmListComponent implements OnInit {
     })
   }
 
-  openAddFarmModal(farm?: Farm) {
+  openAddFarmModal(farm?: Farm): void {
     if (typeof farm === 'undefined'){
       // Create Farm
       this.dialog
@@ -59,6 +60,19 @@ export class FarmListComponent implements OnInit {
           }
         })
     }
+  }
+
+  openDeleteFarmModal(farm: Farm): void {
+    this.dialog.open(DeleteFarmModalComponent, {
+      width: '600px',
+      data: {farm: farm}
+    })
+    .afterClosed()
+    .subscribe(async (response) => {
+      if(response.button === 'deletar'){
+        this.farms = this.farms.filter(obj => obj !== farm);
+      }
+    })
   }
 
 }

--- a/src/app/service/farm.service.ts
+++ b/src/app/service/farm.service.ts
@@ -25,4 +25,8 @@ export class FarmService {
   public updateFarm(id: string, farm: Farm) {
     return this.api.put<Farm>(API_URL + '/farm/' + id, farm);
   }
+
+  public deleteFarm(id: string) {
+    return this.api.delete<Farm>(API_URL + '/farm/' + id);
+  }
 }

--- a/src/app/service/http.service.ts
+++ b/src/app/service/http.service.ts
@@ -31,4 +31,10 @@ export class HttpService {
       .put<T>(url, data, headers)
       .pipe(catchError(errorHandler));
   }
+
+  public delete<T>(url: string): Observable<T> {
+    return this.http
+      .delete<T>(url)
+      .pipe(catchError(errorHandler));
+  }
 }


### PR DESCRIPTION
Aqui a ideia foi a mesma dos últimos três commits, criei o método no serviço que chama o path da api que faz a deleção de uma fazenda por meio de um delete request. Criei uma janela de diálogo nova, conforme o design base, pra que quando o usuário clique em excluir uma fazenda na lista de fazendas essa janela seja aberta e lá ele de fato consiga fazer o delete. 

![image](https://user-images.githubusercontent.com/103016217/171063208-16756160-255d-455a-acb0-9fa0d118b2c3.png)
![image](https://user-images.githubusercontent.com/103016217/171063266-0e3cb3f3-ddee-4929-af60-4876025cec30.png)

